### PR TITLE
fix: find by ids targeted the wrong identifier in the repo

### DIFF
--- a/domain/redirectdefinition/repository/redirectdefinition.go
+++ b/domain/redirectdefinition/repository/redirectdefinition.go
@@ -294,8 +294,10 @@ func (rs *BaseRedirectsDefinitionRepository) DeleteMany(ctx context.Context, ids
 func (rs *BaseRedirectsDefinitionRepository) FindByIDs(ctx context.Context, ids []*storex.EntityID) ([]*storex.RedirectDefinition, error) {
 	var results []*storex.RedirectDefinition
 
-	// Query all redirects matching the given IDs
-	err := rs.collection.Find(ctx, bson.M{"_id": bson.M{"$in": ids}}, &results)
+	// Match on the "id" field that holds the EntityID (consistent with Update,
+	// Delete and DeleteMany). Mongo's "_id" is a separate auto-generated ObjectID,
+	// so querying it here matched nothing.
+	err := rs.collection.Find(ctx, bson.M{"id": bson.M{"$in": ids}}, &results)
 	if err != nil {
 		rs.l.Error("Failed to fetch redirects by IDs", zap.Error(err))
 		return nil, err


### PR DESCRIPTION
### Description

The find by ID operation targeted the internal _id instead of the generated entityID

### Type of Change

<!-- Check the relevant option -->

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance
- [ ] ✅ Tests
- [ ] 🔧 Build/CI

